### PR TITLE
fix: windows breadcrumb Unlimited Sending

### DIFF
--- a/plugins/sentry/guest-js/index.ts
+++ b/plugins/sentry/guest-js/index.ts
@@ -45,7 +45,9 @@ async function sendEventToRust(event: Event): Promise<ErrorEvent | null> {
 function sendBreadcrumbToRust(
   breadcrumb: Breadcrumb
 ): Breadcrumb | null {
-  if (typeof breadcrumb.data?.url === "string" && breadcrumb.data.url.startsWith("ipc://localhost/")) return null
+  if (typeof breadcrumb.data?.url === "string"
+      &&  (breadcrumb.data.url.startsWith("ipc://localhost/") || breadcrumb.data.url.startsWith("http://ipc.localhost/"))
+    ) return null
   invoke("plugin:sentry|breadcrumb", { breadcrumb });
   // We don't collect breadcrumbs in the renderer since they are passed to Rust
   return null;


### PR DESCRIPTION
Tauri IPC use http:// protocol when run in windows, so need exclude http://ipc.localhost/ fetch in sendBreadcrumbToRust function.
![75a961df-c7ff-4e0d-a09b-5685d1922623](https://github.com/user-attachments/assets/ad19676d-986c-4dba-b68a-3678ec035d95)
